### PR TITLE
Add "di:is-linked" LuckPerms context

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.7.0" />
+  </component>
+</project>

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     compileOnly 'me.clip:placeholderapi:2.11.1'
     compileOnly 'org.apache.logging.log4j:log4j-core:2.18.0'
     compileOnly 'org.dynmap:dynmap-api:2.0'
+    compileOnly 'net.luckperms:api:5.4'
 
     implementation 'com.discord4j:discord4j-core:3.2.2'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.2'

--- a/plugin/src/main/kotlin/com/dominikkorsa/discordintegration/DiscordIntegration.kt
+++ b/plugin/src/main/kotlin/com/dominikkorsa/discordintegration/DiscordIntegration.kt
@@ -13,6 +13,7 @@ import com.dominikkorsa.discordintegration.formatter.EmojiFormatter
 import com.dominikkorsa.discordintegration.formatter.MinecraftFormatter
 import com.dominikkorsa.discordintegration.linking.Linking
 import com.dominikkorsa.discordintegration.listener.*
+import com.dominikkorsa.discordintegration.luckperms.registerLuckPerms
 import com.dominikkorsa.discordintegration.update.UpdateCheckerService
 import com.dominikkorsa.discordintegration.utils.bunchLines
 import com.github.shynixn.mccoroutine.bukkit.launch
@@ -70,6 +71,8 @@ class DiscordIntegration : JavaPlugin() {
         initCommands()
         registerAllEvents()
         startLogging()
+        if (registerLuckPerms(this)) logger.info("Luck Perms integration enabled")
+        else logger.info("Luck Perms not available")
 
         this.launch {
             db.init()

--- a/plugin/src/main/kotlin/com/dominikkorsa/discordintegration/luckperms/LinkedContextCalculator.kt
+++ b/plugin/src/main/kotlin/com/dominikkorsa/discordintegration/luckperms/LinkedContextCalculator.kt
@@ -1,0 +1,25 @@
+package com.dominikkorsa.discordintegration.luckperms
+
+import com.dominikkorsa.discordintegration.DiscordIntegration
+import net.luckperms.api.context.ContextCalculator
+import net.luckperms.api.context.ContextConsumer
+import net.luckperms.api.context.ContextSet
+import net.luckperms.api.context.ImmutableContextSet
+import org.bukkit.OfflinePlayer
+
+class LinkedContextCalculator(private val plugin: DiscordIntegration) : ContextCalculator<OfflinePlayer> {
+    companion object {
+        const val contextName = "di:is-linked"
+    }
+
+    override fun calculate(player: OfflinePlayer, consumer: ContextConsumer) {
+        consumer.accept(contextName, (plugin.db.getDiscordId(player.uniqueId) != null).toString())
+    }
+
+    override fun estimatePotentialContexts(): ContextSet {
+        val builder = ImmutableContextSet.builder()
+        builder.add(contextName, "false")
+        builder.add(contextName, "true")
+        return builder.build()
+    }
+}

--- a/plugin/src/main/kotlin/com/dominikkorsa/discordintegration/luckperms/LuckPerms.kt
+++ b/plugin/src/main/kotlin/com/dominikkorsa/discordintegration/luckperms/LuckPerms.kt
@@ -1,0 +1,14 @@
+package com.dominikkorsa.discordintegration.luckperms
+
+import com.dominikkorsa.discordintegration.DiscordIntegration
+import net.luckperms.api.LuckPerms
+import org.bukkit.Bukkit
+import org.bukkit.plugin.RegisteredServiceProvider
+
+fun registerLuckPerms(plugin: DiscordIntegration): Boolean {
+    val provider: RegisteredServiceProvider<LuckPerms> =
+        Bukkit.getServicesManager().getRegistration(LuckPerms::class.java) ?: return false
+    val api: LuckPerms = provider.provider
+    api.contextManager.registerCalculator(LinkedContextCalculator(plugin))
+    return true
+}

--- a/plugin/src/main/resource-templates/plugin.yml
+++ b/plugin/src/main/resource-templates/plugin.yml
@@ -5,6 +5,8 @@ main: com.dominikkorsa.discordintegration.DiscordIntegration
 api-version: 1.13
 softdepend:
   - PlaceholderAPI
+  - dynmap
+  - LuckPerms
 load: STARTUP
 prefix: Discord Integration %plugin-version%
 


### PR DESCRIPTION
Adds a `di:is-linked` context for Luck Perms, which has the value of `true` when the player has linked their Discord account and `false` when they have not.

This allows to assign permissions, so that only the players, who have linked their Discord account, can use specific commands.

![image](https://user-images.githubusercontent.com/29484605/195981230-601c5809-7d22-41ca-af7a-2f162220ca64.png)

Closes #54 