### PR TITLE
Add `%time-short%` and `%time-long%` templates

### DIFF
--- a/plugin/src/main/kotlin/com/dominikkorsa/discordintegration/config/ConfigManager.kt
+++ b/plugin/src/main/kotlin/com/dominikkorsa/discordintegration/config/ConfigManager.kt
@@ -1,9 +1,11 @@
 package com.dominikkorsa.discordintegration.config
 
 import com.dominikkorsa.discordintegration.DiscordIntegration
+import com.dominikkorsa.discordintegration.utils.orNull
 import dev.dejvokep.boostedyaml.block.implementation.Section
 import dev.dejvokep.boostedyaml.route.Route
 import dev.dejvokep.boostedyaml.settings.updater.UpdaterSettings
+import java.util.*
 import java.util.regex.Pattern
 
 class ConfigManager(plugin: DiscordIntegration) : CustomConfig(plugin, "config.yml") {
@@ -90,6 +92,13 @@ class ConfigManager(plugin: DiscordIntegration) : CustomConfig(plugin, "config.y
         val syncNicknames get() = section.requireBoolean("sync-nicknames")
     }
 
+    class DateTime(private val section: Section) {
+        val timezone get() = section.getOptionalString("timezone").orNull()?.let {
+            TimeZone.getTimeZone(it)
+        } ?: TimeZone.getDefault()
+        val is24h get() = section.requireBoolean("24h")
+    }
+
     class Debug(private val section: Section) {
         enum class CancelledChatEventsMode {
             DISABLE,
@@ -117,6 +126,7 @@ class ConfigManager(plugin: DiscordIntegration) : CustomConfig(plugin, "config.y
     val chat get() = Chat(config.getSection("chat"))
     val activity get() = Activity(config.getSection("activity"))
     val linking get() = Linking(config.getSection("linking"))
+    val dateTime get() = DateTime(config.getSection("date-time"))
     val debug get() = Debug(config.getSection("debug"))
 
     companion object {

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -1,5 +1,5 @@
-# Do not edit the file-version!
-file-version: 6
+# Don't edit file-version yourself unless you know what you are doing!
+file-version: 7
 
 # Put your Discord token here:
 discord-token:
@@ -65,6 +65,7 @@ activity:
     # If the number doesn't divide an hour (60) the results might be unexpected
     round: 1
     # Whether to use 24-hour clock (true) or 12-hour clock (false)
+    # for displaying Minecraft time
     24h: true
   idle-when-no-players-online: true
 linking:
@@ -90,6 +91,14 @@ linking:
   # You should remove "Change Nickname" permission from users
   # if this setting is enabled
   sync-nicknames: false
+date-time:
+  # Timezone used for formatting real time in Minecraft
+  # For example Europe/Amsterdam or America/New_York
+  # For the list of all time zone identifiers see:
+  # https://docs.oracle.com/middleware/12211/wcs/tag-ref/MISC/TimeZones.html
+  timezone: GMT
+  # Whether to use 24-hour clock (true) or 12-hour clock (false)
+  24h: true
 debug:
   # Will output each message received from Discord in server console
   log-discord-messages: false


### PR DESCRIPTION
- Add `%time-short%` and `%time-long%` templates for `minecraft.message` and `minecraft.tooltip`, replaced with time of sending a message
- Add `date-time` config section to change timezone and 12h/24h mode of these templates

Fixes #63 